### PR TITLE
markup of the pages of the payment method

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -11,3 +11,4 @@
 @import "modules/signin";
 @import "modules/common";
 @import "modules/identification";
+@import "modules/card";

--- a/app/assets/stylesheets/modules/_card.scss
+++ b/app/assets/stylesheets/modules/_card.scss
@@ -171,10 +171,29 @@
         line-height: 1.5;
       }
     }
-    &>.card-image-list{
+    .card-image-list{
       margin-top: 8px;
       img{
         padding-left: 3px;
+        height: 20px;
+        &.visa{
+          width: 49px;
+        }
+        &.master-card{
+          width: 34px;
+        }
+        &.saison-card{
+          width: 30px;
+        }
+        &.jcb{
+          width: 21px;
+        }
+        &.dinersclub{
+          width: 32px;
+        }
+        &.discover{
+          width: 32px;
+        }
       }
     }
   }

--- a/app/assets/stylesheets/modules/_card.scss
+++ b/app/assets/stylesheets/modules/_card.scss
@@ -1,0 +1,190 @@
+.card{
+  &-main{
+      &-container{
+      margin: 40px auto 0;
+      padding: 0 0 40px;
+      display: flex;
+      flex-direction: row;
+      justify-content: center;
+      & > div{
+        margin: 0 20px;
+      }
+    }
+    &-content{
+      width: 700px;
+      height: 100%;
+      background-color: $white;
+    }
+  }
+  &-chapter{
+      &-container{
+      width: 700px;
+      margin: 0 auto;
+    }
+    &-head{
+      font-size: 24px;
+      padding: 8px 24px;
+      text-align: center;
+      line-height: 1.4;
+      font-weight: bold;
+      border-bottom: 1px solid #f5f5f5;
+    }
+  }
+  &-settings{
+    &-label{
+    text-align: left;
+    width: 320px;
+    margin: 0 auto;
+    font-size: 16px;
+    font-weight: bold;
+    }
+      &-button{
+      text-align: center;
+      padding: 24px 0;
+      width: 320px;
+      margin: 0 auto;
+      .fa-credit-card{
+        margin-right: 16px;
+        font-size: 18px;
+        font-weight: bold;
+      }
+    }
+      &-form{
+      text-align: left;
+      width: 320px;
+      margin: 0 auto;
+    }
+      &-line{
+      height: 1px;
+      width: 100%;
+      border-bottom: 1px solid #eee;
+    }
+      &-link{
+      text-align: right;
+      padding-top: 24px;
+      width: 320px;
+      margin: 0 auto;
+    }
+     &-content{
+      margin: 0 auto;
+    }
+    &-add-left{
+      width: 49%;
+      text-align: left;
+      padding: 24px 0;
+    }
+
+    &-add-right{
+      width: 49%;
+      text-align: right;
+      padding: 24px 0;
+    }
+
+    &-payment-num{
+      margin: 8px 0 0;
+      font-size: 16px;
+    }
+
+    &-payment-remove{
+      padding: 4px 6px;
+      background: #fff;
+      border-radius: 3px;
+      border: 1px solid #ea352d;
+      color: #ea352d;
+    }
+  }
+  &-single-inner{
+    padding: 64px;
+    &-320px{
+      width: 320px;
+      margin: 0 auto;
+      padding: 64px;
+    }
+  }
+  &-input{
+    -webkit-appearance: none;
+    margin: 8px 0 0;
+    padding: 10px 16px 8px;
+    border-radius: 4px;
+    border: 1px solid #ccc;
+    background: #fff;
+    line-height: 1.5;
+    font-size: 16px;
+      &:focus{
+      border: 1px solid #0099e8;
+      outline: 0;
+    }
+  }
+  &-form-group{
+    margin: 40px 0 0;
+    &:first-child{
+      margin: 0;
+    }
+    & .input-default{
+      width: 100%;
+      margin: 8px 0 0;
+    }
+    & label{
+      font-size: 16px;
+      font-weight: 600;
+    }
+    & .textarea-default{
+      margin: 8px 0 0;
+    }
+    & select{
+      width: 100%;
+    }
+    & .select-wrap{
+      margin: 8px 0 0;
+    }
+    & .fa-angle-down{
+      position: absolute;
+      right: 16px;
+      top: 50%;
+      z-index: 2;
+      color: #888;
+      -webkit-transform: translate(0, -50%);
+      transform: translate(0, -50%);
+    }
+    &> .text-center{
+    text-align: center;
+    line-height: 1.5;
+    }
+    &> .text-right{
+      width: 100%;
+      text-align: right;
+      line-height: 1.5;
+    }
+    &>.select-birthday{
+      width: 140px;
+    }
+    &>.inline-block{
+      display: inline-block;
+    }
+    &>.has-error{
+      &>input{
+        border: 1px solid red;
+        outline: 0;
+      }
+      &>.has-error-text{
+        color: red;
+        line-height: 1.5;
+      }
+    }
+    &>.card-image-list{
+      margin-top: 8px;
+      img{
+        padding-left: 3px;
+      }
+    }
+  }
+  &-select-wrap{
+    position: relative;
+  }
+  &-flexbox{
+    display: flex;
+    flex-direction: row;
+    justify-content: space-between;
+    flex-wrap: wrap;
+  }
+}

--- a/app/assets/stylesheets/modules/_signup.scss
+++ b/app/assets/stylesheets/modules/_signup.scss
@@ -189,7 +189,7 @@
     }
   }
 }
-.signup-form-group{
+.card-form-group{
   margin: 40px 0 0;
   &:first-child{
     margin: 0;

--- a/app/controllers/card_controller.rb
+++ b/app/controllers/card_controller.rb
@@ -1,0 +1,2 @@
+class CardController < ApplicationController
+end

--- a/app/views/card/index.html.haml
+++ b/app/views/card/index.html.haml
@@ -1,0 +1,34 @@
+= render "./common/header"
+%nav.bread-crumbs
+  %ul
+    %li
+      %span.mercari
+        = link_to "メルカリ", "#", class: "underline-opacity"
+      = fa_icon "angle-right"
+    %li
+      %span.mercari
+        = link_to "マイページ", "#", class: "underline-opacity"
+      = fa_icon "angle-right"
+    %li
+      %span 支払い方法
+%main.card-main-container
+  = render "./users/sidebar"
+  .card-main-content
+    %h2.card-chapter-head 支払い方法
+    .card-single-content
+      .card-single-inner
+        .signup-form-group
+          %section.card-settings-label
+            クレジットカード一覧
+          %section.card-settings-button
+            = link_to "#", class: "btn-default btn-red opacity-hover" do
+              =fa_icon "credit-card"
+              %span クレジットカードを登録する
+          .card-settings-line
+          .card-settings-link
+            = link_to "#", class: "underline-opacity" do
+              %span 支払い方法について
+              = fa_icon "angle-right"
+= render "./common/app-banner"
+= render "./common/footer"
+= render "./common/sell-btn"

--- a/app/views/card/index.html.haml
+++ b/app/views/card/index.html.haml
@@ -3,7 +3,7 @@
   %ul
     %li
       %span.mercari
-        = link_to "メルカリ", "#", class: "underline-opacity"
+        = link_to "メルカリ", root_path, class: "underline-opacity"
       = fa_icon "angle-right"
     %li
       %span.mercari
@@ -21,7 +21,7 @@
           %section.card-settings-label
             クレジットカード一覧
           %section.card-settings-button
-            = link_to "#", class: "btn-default btn-red opacity-hover" do
+            = link_to new_card_path, class: "btn-default btn-red opacity-hover" do
               =fa_icon "credit-card"
               %span クレジットカードを登録する
           .card-settings-line

--- a/app/views/card/new.html.haml
+++ b/app/views/card/new.html.haml
@@ -3,7 +3,7 @@
   %ul
     %li
       %span.mercari
-        = link_to "メルカリ", "#", class: "underline-opacity"
+        = link_to "メルカリ", root_path, class: "underline-opacity"
       = fa_icon "angle-right"
     %li
       %span.mercari
@@ -11,7 +11,7 @@
       = fa_icon "angle-right"
     %li
       %span.mercari
-        = link_to "支払い方法", "#", class: "underline-opacity"
+        = link_to "支払い方法", card_index_path , class: "underline-opacity"
       = fa_icon "angle-right"
     %li
       %span クレジットカード情報入力
@@ -26,13 +26,13 @@
           %span.form-require 必須
           = text_field_tag "card-id", "", class: "input-default", placeholder: "半角数字のみ"
           .card-image-list
-            = image_tag "card-icon-visa.svg", alt: "visa", size: "49x20"
-            = image_tag "card-icon-master-card.svg", alt: "master-card", size: "34x20"
-            = image_tag "card-icon-saison-card.svg", alt: "saison-card", size: "30x20"
-            = image_tag "card-icon-jcb.svg", alt: "jcb", size: "32x20"
-            = image_tag "card-icon-american_express.svg", alt: "american_express", size: "21x20"
-            = image_tag "card-icon-dinersclub.svg", alt: "dinersclub", size: "32x20"
-            = image_tag "card-icon-discover.svg", alt: "discover", size: "32x20"
+            = image_tag "card-icon-visa.svg", alt: "visa", class: "visa"
+            = image_tag "card-icon-master-card.svg", alt: "master-card", class: "master-card"
+            = image_tag "card-icon-saison-card.svg", alt: "saison-card", class: "saison-card"
+            = image_tag "card-icon-jcb.svg", alt: "jcb", class: "jcb"
+            = image_tag "card-icon-american_express.svg", alt: "american_express", class: "american_express"
+            = image_tag "card-icon-dinersclub.svg", alt: "dinersclub", class: "dinersclub"
+            = image_tag "card-icon-discover.svg", alt: "discover", class: "discover"
         .card-form-group
           %label 有効期限
           %span.form-require 必須
@@ -53,7 +53,7 @@
               = fa_icon "question-circle"
               %span カード裏面の番号とは？
         .card-form-group
-          = link_to "追加する", "#", class: "btn-default btn-red"
+          = link_to "追加する", "../card/show", class: "btn-default btn-red"
 = render "./common/app-banner"
 = render "./common/footer"
 = render "./common/sell-btn"

--- a/app/views/card/new.html.haml
+++ b/app/views/card/new.html.haml
@@ -1,0 +1,59 @@
+= render "./common/header"
+%nav.bread-crumbs
+  %ul
+    %li
+      %span.mercari
+        = link_to "メルカリ", "#", class: "underline-opacity"
+      = fa_icon "angle-right"
+    %li
+      %span.mercari
+        = link_to "マイページ", "#", class: "underline-opacity"
+      = fa_icon "angle-right"
+    %li
+      %span.mercari
+        = link_to "支払い方法", "#", class: "underline-opacity"
+      = fa_icon "angle-right"
+    %li
+      %span クレジットカード情報入力
+%main.card-main-container
+  = render "./users/sidebar"
+  .card-main-content
+    %h2.card-chapter-head クレジットカード情報入力
+    .card-single-content
+      .card-single-inner-320px
+        .card-form-group
+          %label カード
+          %span.form-require 必須
+          = text_field_tag "card-id", "", class: "input-default", placeholder: "半角数字のみ"
+          .card-image-list
+            = image_tag "card-icon-visa.svg", alt: "visa", size: "49x20"
+            = image_tag "card-icon-master-card.svg", alt: "master-card", size: "34x20"
+            = image_tag "card-icon-saison-card.svg", alt: "saison-card", size: "30x20"
+            = image_tag "card-icon-jcb.svg", alt: "jcb", size: "32x20"
+            = image_tag "card-icon-american_express.svg", alt: "american_express", size: "21x20"
+            = image_tag "card-icon-dinersclub.svg", alt: "dinersclub", size: "32x20"
+            = image_tag "card-icon-discover.svg", alt: "discover", size: "32x20"
+        .card-form-group
+          %label 有効期限
+          %span.form-require 必須
+          .card-select-wrap.select-birthday
+            = select "month", "", ["--","1",  "2",  "3",  "4",  "5",  "6",  "7",  "8",  "9",  "10", "11", "12"], {} ,{class: "card-input"}
+            = fa_icon "angle-down 2x"
+            %span 月
+          .card-select-wrap.select-birthday
+            = select "year", "", ["--","2019",  "2020", "2021", "2022", "2023", "2024", "2025", "2026", "2027", "2028", "2029"], {} ,{class: "card-input"}
+            = fa_icon "angle-down 2x"
+            %span 年
+        .card-form-group
+          %label セキュリティコード
+          %span.form-require 必須
+          = text_field_tag "card-id", "", class: "input-default", placeholder: "カード背面4桁もしくは3桁の番号"
+          .text-right
+            = link_to "#", class: "underline-opacity" do
+              = fa_icon "question-circle"
+              %span カード裏面の番号とは？
+        .card-form-group
+          = link_to "追加する", "#", class: "btn-default btn-red"
+= render "./common/app-banner"
+= render "./common/footer"
+= render "./common/sell-btn"

--- a/app/views/card/show.html.haml
+++ b/app/views/card/show.html.haml
@@ -1,0 +1,37 @@
+= render "./common/header"
+%nav.bread-crumbs
+  %ul
+    %li
+      %span.mercari
+        = link_to "メルカリ", "#", class: "underline-opacity"
+      = fa_icon "angle-right"
+    %li
+      %span.mercari
+        = link_to "マイページ", "#", class: "underline-opacity"
+      = fa_icon "angle-right"
+    %li
+      %span 支払い方法
+%main.card-main-container
+  = render "./users/sidebar"
+  .card-main-content
+    %h2.card-chapter-head 支払い方法
+    .card-single-content
+      .card-single-inner-320px
+        .card-form-group
+          %label クレジットカード一覧
+          .card-flexbox
+            .add-card-settings-left
+              =image_tag "card-icon-visa.svg", alt: "visa", size: "34x20"
+              .card-settings-payment-num ************1010
+              .card-settings-payment-num 05 / 23
+            .card-settings-add-right
+              = link_to "削除する", "#", class: "card-settings-payment-remove"
+        .card-settings-line
+        .card-form-group
+          .text-right
+            = link_to "#", class: "underline-opacity" do
+              %span 支払い方法について
+              = fa_icon "angle-right"
+= render "./common/app-banner"
+= render "./common/footer"
+= render "./common/sell-btn"

--- a/app/views/card/show.html.haml
+++ b/app/views/card/show.html.haml
@@ -3,7 +3,7 @@
   %ul
     %li
       %span.mercari
-        = link_to "メルカリ", "#", class: "underline-opacity"
+        = link_to "メルカリ", root_path, class: "underline-opacity"
       = fa_icon "angle-right"
     %li
       %span.mercari
@@ -21,7 +21,8 @@
           %label クレジットカード一覧
           .card-flexbox
             .add-card-settings-left
-              =image_tag "card-icon-visa.svg", alt: "visa", size: "34x20"
+              .card-image-list
+                =image_tag "card-icon-visa.svg", alt: "visa", class: "visa"
               .card-settings-payment-num ************1010
               .card-settings-payment-num 05 / 23
             .card-settings-add-right

--- a/app/views/signup/payment_registration.haml
+++ b/app/views/signup/payment_registration.haml
@@ -30,7 +30,7 @@
               %label カード
               %span.form-require 必須
               = text_field_tag "card-id", "", class: "signup-input", placeholder: "半角数字のみ"
-              .signup-card-list
+              .card-image-list
                 = image_tag "card-icon-visa.svg", alt: "visa", size: "49x20"
                 = image_tag "card-icon-master-card.svg", alt: "master-card", size: "34x20"
                 = image_tag "card-icon-saison-card.svg", alt: "saison-card", size: "30x20"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,6 +5,7 @@ Rails.application.routes.draw do
   root 'top#index'
   resources :items, only: [:index, :new]
   resources :identification, only: [:index]
+  resources :card, only: [:index, :new, :show]
 
   get '/signup', to: 'signup#index', as: 'user_signup'
   get '/signup/sms_confirmation', to: 'signup#sms_confirmation', as: 'sms_confirmation'


### PR DESCRIPTION
## WHAT
I made the pages of the payment method.
1. Add haml files to register payment style
2. Add scss files for pages' decration.
3. edit routes

## WHY
Users will be able to register the information of payment method at those pages.

### The links of each pages is below
/card ->button to start to register
<img width="784" alt="image" src="https://user-images.githubusercontent.com/27143270/54874269-125a9f80-4e2b-11e9-9e0e-5a57a7be9202.png">

/card/new -> input page
<img width="594" alt="image" src="https://user-images.githubusercontent.com/27143270/54874275-21d9e880-4e2b-11e9-82d8-9d2a873268df.png">

/card/show -> show information which is registered
<img width="737" alt="image" src="https://user-images.githubusercontent.com/27143270/54874284-328a5e80-4e2b-11e9-98ad-42fe14f91539.png">
