### PR TITLE
Markup of purchase confirmation page

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -12,3 +12,4 @@
 @import "modules/common";
 @import "modules/identification";
 @import "modules/card";
+@import "modules/purchase";

--- a/app/assets/stylesheets/modules/_common.scss
+++ b/app/assets/stylesheets/modules/_common.scss
@@ -54,3 +54,9 @@
     font-size: 20px;
   }
 }
+
+.link-off {
+ pointer-events: none;
+ cursor: default;
+ text-decoration: none;
+}

--- a/app/assets/stylesheets/modules/_purchase.scss
+++ b/app/assets/stylesheets/modules/_purchase.scss
@@ -1,0 +1,153 @@
+.purchase{
+
+&-container{
+  display: flex;
+  flex-direction: column;
+  height: 100vh;
+}
+
+&-header{
+min-height: 128px;
+display: flex;
+flex-direction: row;
+justify-content:center;
+  h1{
+    padding: 40px 0 0;
+  }
+  &-logo:hover{
+    opacity: 0.8;
+    cursor: pointer;
+  }
+}
+
+&-main{
+  margin: 0 auto;
+  width: 700px;
+  background: white;
+}
+
+&-chapter {
+  padding: 32px 16px;
+  font-size: 24px;
+  line-height: 1.5;
+  text-align: center;
+  border-bottom: 1px solid #f5f5f5;
+}
+
+&-border{
+  margin-top: 40px;
+  content: "";
+  height: 1px;
+  border-top: 1px solid #f5f5f5;
+}
+
+&-item{
+  margin: 0 auto;
+  border-top: none;
+  width: 320px;
+  padding: 24px 0;
+  .single-text{
+    margin: 8px 0 0;
+    padding: 0;
+    line-height: 1.5;
+  }
+  &-image{
+    margin: 0 auto;
+    width: 320px;
+    height: 148px;
+    display: flex;
+    justify-content: center;
+  img{
+    width: auto;
+    height: auto;
+    max-width: 100%;
+    max-height: 100%;
+  }
+}
+&-name{
+  width: 320px;
+  margin: 8px auto 0;
+  font-size: 16px;
+  line-height: 1.5;
+  text-align: center;
+}
+&-form{
+  margin: 8px 0 0;
+  line-height: 1.5;
+  p{
+    margin: 8px 0 0;
+    text-align: center;
+    line-height: 1.5;
+    font-size: 28px;
+  }
+  span{
+    margin: 0 0 0 8px;
+    font-size: 14px;
+    font-weight: 400;
+  }
+  >.btn-red {
+    margin: 16px 0 0;
+  }
+    &-flex-center{
+      display: flex;
+      flex-direction: row;
+      flex-wrap: wrap;
+      justify-content: center;
+      align-items: baseline;
+    }
+    &-flex-spacebetween{
+      display: flex;
+      flex-direction: row;
+      flex-wrap: wrap;
+      justify-content: space-between;
+      align-items: baseline;
+      &-price-left{
+        padding: 16px 0;
+        width: 48%;
+        text-align: left;
+        font-size: 28px;
+        font-weight: 600;
+      }
+      &-price-right{
+        padding: 16px 0;
+        width: 48%;
+        text-align: right;
+        font-size: 28px;
+        font-weight: 600;
+      }
+    }
+    &-accordion-toggle{
+      display: block;
+      margin: 16px 0 0;
+      padding: 16px;
+      background: #ccc;
+      border: 1px solid #ccc;
+      text-align: center;
+      color: #333;
+    }
+  }
+}
+
+&-user{
+  margin: 0 auto;
+  padding-top: 24px;
+  width: 320px;
+  &-info{
+    h3{
+      margin: 40px 0 0;
+      font-size: 14px;
+    }
+  }
+    &-info-text {
+      display: block;
+      margin: 8px 0 0;
+      font-size: 14px;
+      line-height: 1.4;
+    }
+    &-info-text-right{
+      width: 100%;
+      text-align: right;
+      line-height: 1.5;
+    }
+  }
+}

--- a/app/controllers/purchase_controller.rb
+++ b/app/controllers/purchase_controller.rb
@@ -1,0 +1,2 @@
+class PurchaseController < ApplicationController
+end

--- a/app/views/purchase/index.html.haml
+++ b/app/views/purchase/index.html.haml
@@ -1,3 +1,47 @@
-= render "./common/header"
-
-= render "./common/footer"
+.purchase-container
+  %header.purchase-header
+    %h1
+      = link_to image_tag("logo.svg",  width: "185", alt: "logo", class: "purchase-header-logo"), "#"
+  %main.purchase-main
+    %h2.purchase-chapter 購入を確定しますか？
+    %section.purchase-item
+      .purchase-item-image
+        =image_tag "item-2.jpg"
+      .purchase-item-name.bold Apple MacBook Pro 13インチ
+      .purchase-item-form
+        .purchase-item-form-flex-center
+          %p.bold ¥16,700円
+          %span 送料込み
+        = link_to "ポイントはありません", "#", class: "purchase-item-form-accordion-toggle link-off"
+        .purchase-item-form-flex-spacebetween
+          .purchase-item-form-flex-spacebetween-price-left 支払い金額
+          .purchase-item-form-flex-spacebetween-price-right ¥135,000
+        = link_to "購入する", "#", class: "btn-default btn-red bold"
+    %section.purchase-border
+    %section.purchase-user
+      %h3.purchase-user-info 配送先
+      %adress.purchase-user-info-text
+        〒000-0000
+        %br
+        東京都昭島市玉川町3−33−333
+        %br
+        アルビレンチ札幌301号室
+        %br
+        さとう たける
+      .purchase-user-info-text-right
+        = link_to "#", class: "underline-opacity" do
+          %span 変更する
+          = fa_icon "angle-right"
+    %section.purchase-border
+    %section.purchase-user
+      %h3.purchase-user-info 支払い方法
+      %p.purchase-user-info-text
+        ************1010
+        %br
+        05 / 23
+      .purchase-user-info-text-right
+        = link_to "#", class: "underline-opacity" do
+          %span 変更する
+          = fa_icon "angle-right"
+    %section.purchase-border
+  = render "./common/footer-singlefooter"

--- a/app/views/purchase/index.html.haml
+++ b/app/views/purchase/index.html.haml
@@ -1,0 +1,3 @@
+= render "./common/header"
+
+= render "./common/footer"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,6 +6,7 @@ Rails.application.routes.draw do
   resources :items, only: [:index, :new]
   resources :identification, only: [:index]
   resources :card, only: [:index, :new, :show]
+  resources :purchase, only: [:index]
 
   get '/signup', to: 'signup#index', as: 'user_signup'
   get '/signup/sms_confirmation', to: 'signup#sms_confirmation', as: 'sms_confirmation'


### PR DESCRIPTION
## WHAT
Markup the page of purchasing item confirmation

## WHY
To be able to purchase item

### PAGE COMPONENTS 
1.Add an haml/html file to purchase item
2.Add scss/css files to decorate html
3.Add "link-off" function code to commom.scss files because it'll become useful for not only me but also collaborators

### PAGE IMAGE
<img width="394" alt="image" src="https://user-images.githubusercontent.com/27143270/54898500-ee24be80-4f0f-11e9-802a-e546cfb48589.png">