### PR TITLE
Markup of breadcrumbs list

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -66,7 +66,7 @@ end
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem
 gem 'tzinfo-data', platforms: [:mingw, :mswin, :x64_mingw, :jruby]
 
-gem "font-awesome-rails"
+gem 'font-awesome-rails'
 
 gem 'haml-rails'
 
@@ -84,4 +84,6 @@ gem 'omniauth-facebook'
 
 gem 'omniauth-google-oauth2'
 
-gem "dotenv-rails"
+gem 'dotenv-rails'
+
+gem 'gretel'

--- a/app/assets/stylesheets/modules/_items.scss
+++ b/app/assets/stylesheets/modules/_items.scss
@@ -1,4 +1,4 @@
-.bread-crumbs {
+nav.breadcrumbs {
   border-top: 1px solid #eee;
   box-shadow: 0 3px 3px 0 rgba(0,0,0,0.16);
   background: #fff;
@@ -7,14 +7,17 @@
     margin: auto;
     padding: 16px 0;
     li{
-        list-style: none;
-        display: inline-block;
-        font-weight: bold;
-        span.mercari{
-          font-weight: normal;
+      list-style: none;
+      display: inline-block;
+      font-weight: bold;
         a{
           color: black;
+          font-weight: normal;
+          cursor: pointer;
         }
+        a:hover{
+        opacity: 0.6;
+        text-decoration: underline;
       }
     }
   }

--- a/app/views/items/index.html.haml
+++ b/app/views/items/index.html.haml
@@ -1,13 +1,9 @@
 = render "./common/header"
-
-%nav.bread-crumbs
+%nav.breadcrumbs
   %ul
+    - breadcrumb :item_name
     %li
-      %span.mercari
-        = link_to "メルカリ  ", "#", class: "underline-opacity"
-      = fa_icon "angle-right"
-    %li
-      %span HHKB Professional 2 英語配列 墨 静電容量無接点
+      = breadcrumbs separator: "#{content_tag(:i, '', class: 'fa fa-angle-right')}"
 %section.item-box-container.l-single-container
   %h1.item-name HHKB Professional 2 英語配列 墨 静電容量無接点
   %p.item-wording

--- a/config/breadcrumbs.rb
+++ b/config/breadcrumbs.rb
@@ -1,0 +1,14 @@
+crumb :root do
+  link 'メルカリ', root_path
+end
+
+crumb :items do
+  link "アイテム", items_path
+  parent :root
+end
+
+crumb :item_name do
+  link "HHKB Professional 2 英語配列 墨 静電容量無接点", items_path
+  parent :items
+end
+


### PR DESCRIPTION
## WHAT
Breadcrumbs list installed below header bar.
This is temporary code for item page. The final version for installing other pages will be written after discussion.
(補足：今回はitemsのページのみに設置しておりますが、今後別ベージには他の方の作成しているものとすり合わせて設置します。)

## WHY
To let users know the page which they see as of now.

### the image of breadcrumbs list
![8008369cc22751d6d088a50ea686dea9](https://user-images.githubusercontent.com/27143270/55301211-5c203700-5476-11e9-8964-d7fc8b0b646a.gif)